### PR TITLE
Fixes 5.3 - Missing Check for lastSync

### DIFF
--- a/src/contracts/SfrxUsd2OracleImplementation.sol
+++ b/src/contracts/SfrxUsd2OracleImplementation.sol
@@ -158,13 +158,14 @@ contract SfrxUsd2OracleImplementation is GapFirst11, OracleAllowlist, Ownable2St
     /// @notice Set pricePerShareStored, pricePerShareIncPerSecond, and lastSync in one call
     /// @param _newPricePerShareStored New stored price per share, in E18 asset tokens
     /// @param _newPricePerShareIncPerSecond New stored price per share increase per second, in E18 asset tokens
-    /// @param _newLastSync New lastSync
+    /// @param _newLastSync New lastSync, must not be gt `block.timestamp`
     /// @dev p(t) = p0*e^(r(t-t0))
     function setAllPricingParams(
         uint256 _newPricePerShareStored,
         uint256 _newPricePerShareIncPerSecond,
         uint256 _newLastSync
     ) public onlyAllowed {
+        if (_newLastSync > block.timestamp) revert LastSyncInFuture();
         pricePerShareStored = _newPricePerShareStored;
         pricePerShareIncPerSecond = _newPricePerShareIncPerSecond;
         lastSync = _newLastSync;
@@ -209,4 +210,5 @@ contract SfrxUsd2OracleImplementation is GapFirst11, OracleAllowlist, Ownable2St
 
     error AlreadyInit();
     error CastError();
+    error LastSyncInFuture();
 }

--- a/src/test/sfrxUsd2FraxtalOracle/TestsfrxUsd2Dynamic.t.sol
+++ b/src/test/sfrxUsd2FraxtalOracle/TestsfrxUsd2Dynamic.t.sol
@@ -213,6 +213,11 @@ contract TestSrxUsd2OracleDynamic is FraxTest {
         uint256 out = mintRedeemer.deposit(100e18, carl);
         // console.log("Amount out: ", out);
     }
+
+    function test_cannot_setLastSyncInFuture() public {
+        vm.expectRevert(bytes4(keccak256("LastSyncInFuture()")));
+        instance.setAllPricingParams(1_137_989_069_558_259_178, 4_431_822_119, block.timestamp + 100);
+    }
 }
 
 interface IERC4626Vault {


### PR DESCRIPTION
Fixes Issue 5.3 - Removes possibility to set an invalid parameter, within the admin setter setter function. 